### PR TITLE
Fix querying of wildcard permissions with any/wildcard/sub-right queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ $ istanbul cover _mocha -- -R spec
 
 ## Changelog
 
+### 0.4.6
+- fixed querying for permissions `a:b:*:c` with query `a:?:$:d` resulting in `b` instead of `[]`.
+
 ### 0.4.5
 - fixed a permission where an explicit star at the end would not overpower previous more fine-granular permissions
 

--- a/dist/shiro-trie.js
+++ b/dist/shiro-trie.js
@@ -163,19 +163,27 @@ function _expandTrie(trie, array) {
   var a = [].concat(array);
 
   return Object.keys(trie).map(function (node) {
+    var recurse = false;
     if (node === '*') {
-      return [node];
+      if (array.length <= 1 || Object.keys(trie[node]).length === 0) {
+        return [node];
+      }
+      recurse = true;
     }
-    if (array[0] === node || array[0] === '$') {
+    if (node === '*' || array[0] === node || array[0] === '$') {
       if (array.length <= 1) {
         return [node];
       }
-      var child = _expandTrie(trie[node], array.slice(1));
-      return child.map(function (inner) {
-        return node + ':' + inner;
-      });
+      recurse = true;
     }
-    return [];
+
+    if (!recurse) {
+      return [];
+    }
+    var child = _expandTrie(trie[node], array.slice(1));
+    return child.map(function (inner) {
+      return node + ':' + inner;
+    });
   }).reduce(function (a, b) {
     return a.concat(b);
   }, []);

--- a/index.js
+++ b/index.js
@@ -162,19 +162,27 @@ function _expandTrie(trie, array) {
   var a = [].concat(array);
 
   return Object.keys(trie).map(function (node) {
+    var recurse = false;
     if (node === '*') {
-      return [node];
+      if (array.length <= 1 || Object.keys(trie[node]).length === 0) {
+        return [node];
+      }
+      recurse = true;
     }
-    if (array[0] === node || array[0] === '$') {
+    if (node === '*' || array[0] === node || array[0] === '$') {
       if (array.length <= 1) {
         return [node];
       }
-      var child = _expandTrie(trie[node], array.slice(1));
-      return child.map(function (inner) {
-        return node + ':' + inner;
-      });
+      recurse = true;
     }
-    return [];
+
+    if (!recurse) {
+      return [];
+    }
+    var child = _expandTrie(trie[node], array.slice(1));
+    return child.map(function (inner) {
+      return node + ':' + inner;
+    });
   }).reduce(function (a, b) {
     return a.concat(b);
   }, []);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shiro-trie",
-  "version": "0.4.4",
+  "version": "0.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shiro-trie",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Check permissions using Shiro-like strings, put in a trie.",
   "homepage": "https://github.com/entrecode/shiro-trie",
   "main": "index.js",

--- a/test/shiro-trie.test.js
+++ b/test/shiro-trie.test.js
@@ -373,11 +373,11 @@ describe('shiro-trie node module', function () {
       expect(shiroTrie.newTrie().permissions('a:b')).to.eql([]);
       done();
     });
-    it('wildcard in the middle', function (done) {
+    it('wildcard in the middle and lookup right after it', function (done) {
       expect(trie.permissions('k:l:?')).to.eql(['m', 'l', 'n']);
       done();
     });
-    it('wildcard in the middle', function (done) {
+    it('ignored wildcard with lookup after it', function (done) {
       expect(trie.permissions('k:$:?')).to.eql(['l', 'n', 'm']);
       done();
     });

--- a/test/shiro-trie.test.js
+++ b/test/shiro-trie.test.js
@@ -305,6 +305,7 @@ describe('shiro-trie node module', function () {
       trie.add('d:1,2,3:read,write', 'd:4:read', 'x', 'a:1:b:3,4', 'a:2:b:5,6');
       trie.add('z:1,2:y:*', 'z:2,3,4:y:x', 'z:3,4,5:w:v');
       trie.add('k:*:l,n', 'k:l:m');
+      trie.add('m:n:*:p:q');
       done();
     });
     it('simple id lookup', function (done) {
@@ -378,6 +379,22 @@ describe('shiro-trie node module', function () {
     });
     it('wildcard in the middle', function (done) {
       expect(trie.permissions('k:$:?')).to.eql(['l', 'n', 'm']);
+      done();
+    });
+    it('simple id lookup with any and explicit sub-right at end', function (done) {
+      expect(trie.permissions('m:?:$:p')).to.eql(['n']);
+      done();
+    });
+    it('simple id lookup with any and multiple explicit sub-right at end', function (done) {
+      expect(trie.permissions('m:?:$:p:q')).to.eql(['n']);
+      done();
+    });
+    it('simple id lookup with any and wrong explicit sub-right at end', function (done) {
+      expect(trie.permissions('m:?:$:q')).to.eql([]);
+      done();
+    });
+    it('simple id lookup with any and wrong explicit sub-right at end #2', function (done) {
+      expect(trie.permissions('m:?:$:p:z')).to.eql([]);
       done();
     });
   });


### PR DESCRIPTION
Given shiro trie containing: `a:b:*:c`, querying it with `a:?:$:d` should result in `[]` and not in `b` as it was doing before. 