### PR TITLE
#132 add return type to constructor definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare module 'shiro-trie' {
   }
 
   export interface ShiroTrie {
-    constructor();
+    constructor(): ShiroTrie;
 
     reset: () => ShiroTrie;
 


### PR DESCRIPTION
The existing constructor type definition without a return type does not compile when `tsconfig.json` is setup with strict mode enabled